### PR TITLE
Patched make files for compiling on Ubuntu

### DIFF
--- a/patched_make_files/musl-src/Makefile
+++ b/patched_make_files/musl-src/Makefile
@@ -1,0 +1,236 @@
+#
+# Makefile for musl (requires GNU make)
+#
+# This is how simple every makefile should be...
+# No, I take that back - actually most should be less than half this size.
+#
+# Use config.mak to override any of the following variables.
+# Do not make changes here.
+#
+
+srcdir = .
+exec_prefix = /usr/local
+bindir = $(exec_prefix)/bin
+
+prefix = /usr/local/musl
+includedir = $(prefix)/include
+libdir = $(prefix)/lib
+syslibdir = /lib
+
+SRC_DIRS = $(addprefix $(srcdir)/,src/* crt ldso $(COMPAT_SRC_DIRS))
+BASE_GLOBS = $(addsuffix /*.c,$(SRC_DIRS))
+ARCH_GLOBS = $(addsuffix /$(ARCH)/*.[csS],$(SRC_DIRS))
+BASE_SRCS = $(sort $(wildcard $(BASE_GLOBS)))
+ARCH_SRCS = $(sort $(wildcard $(ARCH_GLOBS)))
+BASE_OBJS = $(patsubst $(srcdir)/%,%.o,$(basename $(BASE_SRCS)))
+ARCH_OBJS = $(patsubst $(srcdir)/%,%.o,$(basename $(ARCH_SRCS)))
+REPLACED_OBJS = $(sort $(subst /$(ARCH)/,/,$(ARCH_OBJS)))
+ALL_OBJS = $(addprefix obj/, $(filter-out $(REPLACED_OBJS), $(sort $(BASE_OBJS) $(ARCH_OBJS))))
+
+LIBC_OBJS = $(filter obj/src/%,$(ALL_OBJS)) $(filter obj/compat/%,$(ALL_OBJS))
+LDSO_OBJS = $(filter obj/ldso/%,$(ALL_OBJS:%.o=%.lo))
+CRT_OBJS = $(filter obj/crt/%,$(ALL_OBJS))
+
+AOBJS = $(LIBC_OBJS)
+LOBJS = $(LIBC_OBJS:.o=.lo)
+GENH = obj/include/bits/alltypes.h obj/include/bits/syscall.h
+GENH_INT = obj/src/internal/version.h
+IMPH = $(addprefix $(srcdir)/, src/internal/stdio_impl.h src/internal/pthread_impl.h src/internal/locale_impl.h src/internal/libc.h)
+
+LDFLAGS =
+LDFLAGS_AUTO =
+LIBCC = -lgcc
+CPPFLAGS =
+CFLAGS =
+CFLAGS_AUTO = -Os -pipe
+CFLAGS_C99FSE = -std=c99 -ffreestanding -nostdinc 
+
+CFLAGS_ALL = -fno-stack-protector $(CFLAGS_C99FSE)
+CFLAGS_ALL += -D_XOPEN_SOURCE=700 -I$(srcdir)/arch/$(ARCH) -I$(srcdir)/arch/generic -Iobj/src/internal -I$(srcdir)/src/include -I$(srcdir)/src/internal -Iobj/include -I$(srcdir)/include
+CFLAGS_ALL += $(CPPFLAGS) $(CFLAGS_AUTO) $(CFLAGS)
+
+LDFLAGS_ALL = $(LDFLAGS_AUTO) $(LDFLAGS)
+
+AR      = $(CROSS_COMPILE)ar
+RANLIB  = $(CROSS_COMPILE)ranlib
+INSTALL = $(srcdir)/tools/install.sh
+
+ARCH_INCLUDES = $(wildcard $(srcdir)/arch/$(ARCH)/bits/*.h)
+GENERIC_INCLUDES = $(wildcard $(srcdir)/arch/generic/bits/*.h)
+INCLUDES = $(wildcard $(srcdir)/include/*.h $(srcdir)/include/*/*.h)
+ALL_INCLUDES = $(sort $(INCLUDES:$(srcdir)/%=%) $(GENH:obj/%=%) $(ARCH_INCLUDES:$(srcdir)/arch/$(ARCH)/%=include/%) $(GENERIC_INCLUDES:$(srcdir)/arch/generic/%=include/%))
+
+EMPTY_LIB_NAMES = m rt pthread crypt util xnet resolv dl
+EMPTY_LIBS = $(EMPTY_LIB_NAMES:%=lib/lib%.a)
+CRT_LIBS = $(addprefix lib/,$(notdir $(CRT_OBJS)))
+STATIC_LIBS = lib/libc.a
+SHARED_LIBS = lib/libc.so
+TOOL_LIBS = lib/musl-gcc.specs
+ALL_LIBS = $(CRT_LIBS) $(STATIC_LIBS) $(SHARED_LIBS) $(EMPTY_LIBS) $(TOOL_LIBS)
+ALL_TOOLS = obj/musl-gcc
+
+WRAPCC_GCC = gcc
+WRAPCC_CLANG = clang
+
+LDSO_PATHNAME = $(syslibdir)/ld-musl-$(ARCH)$(SUBARCH).so.1
+
+-include config.mak
+-include $(srcdir)/arch/$(ARCH)/arch.mak
+
+ifeq ($(ARCH),)
+
+all:
+	@echo "Please set ARCH in config.mak before running make."
+	@exit 1
+
+else
+
+all: $(ALL_LIBS) $(ALL_TOOLS)
+
+OBJ_DIRS = $(sort $(patsubst %/,%,$(dir $(ALL_LIBS) $(ALL_TOOLS) $(ALL_OBJS) $(GENH) $(GENH_INT))) obj/include)
+
+$(ALL_LIBS) $(ALL_TOOLS) $(ALL_OBJS) $(ALL_OBJS:%.o=%.lo) $(GENH) $(GENH_INT): | $(OBJ_DIRS)
+
+$(OBJ_DIRS):
+	mkdir -p $@
+
+obj/include/bits/alltypes.h: $(srcdir)/arch/$(ARCH)/bits/alltypes.h.in $(srcdir)/include/alltypes.h.in $(srcdir)/tools/mkalltypes.sed
+	sed -f $(srcdir)/tools/mkalltypes.sed $(srcdir)/arch/$(ARCH)/bits/alltypes.h.in $(srcdir)/include/alltypes.h.in > $@
+
+obj/include/bits/syscall.h: $(srcdir)/arch/$(ARCH)/bits/syscall.h.in
+	cp $< $@
+	sed -n -e s/__NR_/SYS_/p < $< >> $@
+
+obj/src/internal/version.h: $(wildcard $(srcdir)/VERSION $(srcdir)/.git)
+	printf '#define VERSION "%s"\n' "$$(cd $(srcdir); sh tools/version.sh)" > $@
+
+obj/src/internal/version.o obj/src/internal/version.lo: obj/src/internal/version.h
+
+obj/crt/rcrt1.o obj/ldso/dlstart.lo obj/ldso/dynlink.lo: $(srcdir)/src/internal/dynlink.h $(srcdir)/arch/$(ARCH)/reloc.h
+
+obj/crt/crt1.o obj/crt/scrt1.o obj/crt/rcrt1.o obj/ldso/dlstart.lo: $(srcdir)/arch/$(ARCH)/crt_arch.h
+
+obj/crt/rcrt1.o: $(srcdir)/ldso/dlstart.c
+
+obj/crt/Scrt1.o obj/crt/rcrt1.o: CFLAGS_ALL += -fPIC
+
+OPTIMIZE_SRCS = $(wildcard $(OPTIMIZE_GLOBS:%=$(srcdir)/src/%))
+$(OPTIMIZE_SRCS:$(srcdir)/%.c=obj/%.o) $(OPTIMIZE_SRCS:$(srcdir)/%.c=obj/%.lo): CFLAGS += -O3
+
+MEMOPS_OBJS = $(filter %/memcpy.o %/memmove.o %/memcmp.o %/memset.o, $(LIBC_OBJS))
+$(MEMOPS_OBJS) $(MEMOPS_OBJS:%.o=%.lo): CFLAGS_ALL += $(CFLAGS_MEMOPS)
+
+NOSSP_OBJS = $(CRT_OBJS) $(LDSO_OBJS) $(filter \
+	%/__libc_start_main.o %/__init_tls.o %/__stack_chk_fail.o \
+	%/__set_thread_area.o %/memset.o %/memcpy.o \
+	, $(LIBC_OBJS))
+$(NOSSP_OBJS) $(NOSSP_OBJS:%.o=%.lo): CFLAGS_ALL += $(CFLAGS_NOSSP)
+
+$(CRT_OBJS): CFLAGS_ALL += -DCRT
+
+$(LOBJS) $(LDSO_OBJS): CFLAGS_ALL += -fPIC
+
+CC_CMD = $(CC) $(CFLAGS_ALL) -c -o $@ $<
+
+# Choose invocation of assembler to be used
+ifeq ($(ADD_CFI),yes)
+	AS_CMD = LC_ALL=C awk -f $(srcdir)/tools/add-cfi.common.awk -f $(srcdir)/tools/add-cfi.$(ARCH).awk $< | $(CC) $(CFLAGS_ALL) -x assembler -c -o $@ -
+else
+	AS_CMD = $(CC_CMD)
+endif
+
+obj/%.o: $(srcdir)/%.s
+	$(AS_CMD)
+
+obj/%.o: $(srcdir)/%.S
+	$(CC_CMD)
+
+obj/%.o: $(srcdir)/%.c $(GENH) $(IMPH)
+	$(CC_CMD)
+
+obj/%.lo: $(srcdir)/%.s
+	$(AS_CMD)
+
+obj/%.lo: $(srcdir)/%.S
+	$(CC_CMD)
+
+obj/%.lo: $(srcdir)/%.c $(GENH) $(IMPH)
+	$(CC_CMD)
+
+lib/libc.so: $(LOBJS) $(LDSO_OBJS)
+	$(CC) $(CFLAGS_ALL) $(LDFLAGS_ALL) -nostdlib -shared \
+	-Wl,-e,_dlstart -o $@ $(LOBJS) $(LDSO_OBJS) $(LIBCC)
+
+lib/libc.a: $(AOBJS)
+	rm -f $@
+	$(AR) rc $@ $(AOBJS)
+	$(RANLIB) $@
+
+$(EMPTY_LIBS):
+	rm -f $@
+	$(AR) rc $@
+
+lib/%.o: obj/crt/$(ARCH)/%.o
+	cp $< $@
+
+lib/%.o: obj/crt/%.o
+	cp $< $@
+
+lib/musl-gcc.specs: $(srcdir)/tools/musl-gcc.specs.sh config.mak
+	sh $< "$(includedir)" "$(libdir)" "$(LDSO_PATHNAME)" > $@
+
+obj/musl-gcc: config.mak
+	printf '#!/bin/sh\nexec "$${REALGCC:-$(WRAPCC_GCC)}" "$$@" -specs "%s/musl-gcc.specs"\n' "$(libdir)" > $@
+	chmod +x $@
+
+obj/%-clang: $(srcdir)/tools/%-clang.in config.mak
+	sed -e 's!@CC@!$(WRAPCC_CLANG)!g' -e 's!@PREFIX@!$(prefix)!g' -e 's!@INCDIR@!$(includedir)!g' -e 's!@LIBDIR@!$(libdir)!g' -e 's!@LDSO@!$(LDSO_PATHNAME)!g' $< > $@
+	chmod +x $@
+
+$(DESTDIR)$(bindir)/%: obj/%
+	$(INSTALL) -D $< $@
+
+$(DESTDIR)$(libdir)/%.so: lib/%.so
+	$(INSTALL) -D -m 755 $< $@
+
+$(DESTDIR)$(libdir)/%: lib/%
+	$(INSTALL) -D -m 644 $< $@
+
+$(DESTDIR)$(includedir)/bits/%: $(srcdir)/arch/$(ARCH)/bits/%
+	$(INSTALL) -D -m 644 $< $@
+
+$(DESTDIR)$(includedir)/bits/%: $(srcdir)/arch/generic/bits/%
+	$(INSTALL) -D -m 644 $< $@
+
+$(DESTDIR)$(includedir)/bits/%: obj/include/bits/%
+	$(INSTALL) -D -m 644 $< $@
+
+$(DESTDIR)$(includedir)/%: $(srcdir)/include/%
+	$(INSTALL) -D -m 644 $< $@
+
+$(DESTDIR)$(LDSO_PATHNAME): $(DESTDIR)$(libdir)/libc.so
+	$(INSTALL) -D -l $(libdir)/libc.so $@ || true
+
+install-libs: $(ALL_LIBS:lib/%=$(DESTDIR)$(libdir)/%) $(if $(SHARED_LIBS),$(DESTDIR)$(LDSO_PATHNAME),)
+
+install-headers: $(ALL_INCLUDES:include/%=$(DESTDIR)$(includedir)/%)
+
+install-tools: $(ALL_TOOLS:obj/%=$(DESTDIR)$(bindir)/%)
+
+install: install-libs install-headers install-tools
+
+musl-git-%.tar.gz: .git
+	 git --git-dir=$(srcdir)/.git archive --format=tar.gz --prefix=$(patsubst %.tar.gz,%,$@)/ -o $@ $(patsubst musl-git-%.tar.gz,%,$@)
+
+musl-%.tar.gz: .git
+	 git --git-dir=$(srcdir)/.git archive --format=tar.gz --prefix=$(patsubst %.tar.gz,%,$@)/ -o $@ v$(patsubst musl-%.tar.gz,%,$@)
+
+endif
+
+clean:
+	rm -rf obj lib
+
+distclean: clean
+	rm -f config.mak
+
+.PHONY: all clean install install-libs install-headers install-tools

--- a/patched_make_files/physfs-3.0.2/CMakeLists.txt
+++ b/patched_make_files/physfs-3.0.2/CMakeLists.txt
@@ -1,0 +1,306 @@
+# PhysicsFS; a portable, flexible file i/o abstraction.
+#
+# Please see the file LICENSE.txt in the source's root directory.
+
+# The CMake project file is meant to get this compiling on all sorts of
+#  platforms quickly, and serve as the way Unix platforms and Linux distros
+#  package up official builds, but you don't _need_ to use this; we have
+#  built PhysicsFS to (hopefully) be able to drop into your project and
+#  compile, using preprocessor checks for platform-specific bits instead of
+#  testing in here.
+
+cmake_minimum_required(VERSION 2.8.4)
+
+project(PhysicsFS)
+set(PHYSFS_VERSION 3.0.2)
+
+# Increment this if/when we break backwards compatibility.
+set(PHYSFS_SOVERSION 1)
+
+# I hate that they define "WIN32" ... we're about to move to Win64...I hope!
+if(WIN32 AND NOT WINDOWS)
+    set(WINDOWS TRUE)
+endif()
+
+include_directories(./src)
+
+if(APPLE)
+    set(OTHER_LDFLAGS ${OTHER_LDFLAGS} "-framework IOKit -framework Foundation")
+    set(PHYSFS_M_SRCS src/physfs_platform_apple.m)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCC)
+    # Don't use -rpath.
+    set(CMAKE_SKIP_RPATH ON CACHE BOOL "Skip RPATH" FORCE)
+endif()
+
+if(CMAKE_C_COMPILER_ID STREQUAL "SunPro")
+    add_definitions(-erroff=E_EMPTY_TRANSLATION_UNIT)
+    add_definitions(-xldscope=hidden)
+endif()
+
+if(HAIKU)
+    # We add this explicitly, since we don't want CMake to think this
+    #  is a C++ project unless we're on Haiku.
+    set(PHYSFS_CPP_SRCS src/physfs_platform_haiku.cpp)
+    find_library(BE_LIBRARY be)
+    find_library(ROOT_LIBRARY root)
+    set(OPTIONAL_LIBRARY_LIBS ${OPTIONAL_LIBRARY_LIBS} ${BE_LIBRARY} ${ROOT_LIBRARY})
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "WindowsPhone" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    set(WINRT TRUE)
+endif()
+
+if(WINRT)
+    set(PHYSFS_CPP_SRCS src/physfs_platform_winrt.cpp)
+endif()
+
+if(UNIX AND NOT WINDOWS AND NOT APPLE)  # (MingW and such might be UNIX _and_ WINDOWS!)
+    find_library(PTHREAD_LIBRARY pthread)
+    if(PTHREAD_LIBRARY)
+        set(OPTIONAL_LIBRARY_LIBS ${OPTIONAL_LIBRARY_LIBS} ${PTHREAD_LIBRARY})
+    endif()
+endif()
+
+# Almost everything is "compiled" here, but things that don't apply to the
+#  build are #ifdef'd out. This is to make it easy to embed PhysicsFS into
+#  another project or bring up a new build system: just compile all the source
+#  code and #define the things you want.
+set(PHYSFS_SRCS
+    src/physfs.c
+    src/physfs_byteorder.c
+    src/physfs_unicode.c
+    src/physfs_platform_posix.c
+    src/physfs_platform_unix.c
+    src/physfs_platform_windows.c
+    src/physfs_platform_os2.c
+    src/physfs_platform_qnx.c
+    src/physfs_archiver_dir.c
+    src/physfs_archiver_unpacked.c
+    src/physfs_archiver_grp.c
+    src/physfs_archiver_hog.c
+    src/physfs_archiver_7z.c
+    src/physfs_archiver_mvl.c
+    src/physfs_archiver_qpak.c
+    src/physfs_archiver_wad.c
+    src/physfs_archiver_zip.c
+    src/physfs_archiver_slb.c
+    src/physfs_archiver_iso9660.c
+    src/physfs_archiver_vdf.c
+    ${PHYSFS_CPP_SRCS}
+    ${PHYSFS_M_SRCS}
+)
+
+
+# Archivers ...
+# These are (mostly) on by default now, so these options are only useful for
+#  disabling them.
+
+option(PHYSFS_ARCHIVE_ZIP "Enable ZIP support" TRUE)
+if(NOT PHYSFS_ARCHIVE_ZIP)
+    add_definitions(-DPHYSFS_SUPPORTS_ZIP=0)
+endif()
+
+option(PHYSFS_ARCHIVE_7Z "Enable 7zip support" TRUE)
+if(NOT PHYSFS_ARCHIVE_7Z)
+    add_definitions(-DPHYSFS_SUPPORTS_7Z=0)
+endif()
+
+option(PHYSFS_ARCHIVE_GRP "Enable Build Engine GRP support" TRUE)
+if(NOT PHYSFS_ARCHIVE_GRP)
+    add_definitions(-DPHYSFS_SUPPORTS_GRP=0)
+endif()
+
+option(PHYSFS_ARCHIVE_WAD "Enable Doom WAD support" TRUE)
+if(NOT PHYSFS_ARCHIVE_WAD)
+    add_definitions(-DPHYSFS_SUPPORTS_WAD=0)
+endif()
+
+option(PHYSFS_ARCHIVE_HOG "Enable Descent I/II HOG support" TRUE)
+if(NOT PHYSFS_ARCHIVE_HOG)
+    add_definitions(-DPHYSFS_SUPPORTS_HOG=0)
+endif()
+
+option(PHYSFS_ARCHIVE_MVL "Enable Descent I/II MVL support" TRUE)
+if(NOT PHYSFS_ARCHIVE_MVL)
+    add_definitions(-DPHYSFS_SUPPORTS_MVL=0)
+endif()
+
+option(PHYSFS_ARCHIVE_QPAK "Enable Quake I/II QPAK support" TRUE)
+if(NOT PHYSFS_ARCHIVE_QPAK)
+    add_definitions(-DPHYSFS_SUPPORTS_QPAK=0)
+endif()
+
+option(PHYSFS_ARCHIVE_SLB "Enable I-War / Independence War SLB support" TRUE)
+if(NOT PHYSFS_ARCHIVE_SLB)
+    add_definitions(-DPHYSFS_SUPPORTS_SLB=0)
+endif()
+
+option(PHYSFS_ARCHIVE_ISO9660 "Enable ISO9660 support" TRUE)
+if(NOT PHYSFS_ARCHIVE_ISO9660)
+    add_definitions(-DPHYSFS_SUPPORTS_ISO9660=0)
+endif()
+
+option(PHYSFS_ARCHIVE_VDF "Enable Gothic I/II VDF archive support" TRUE)
+if(NOT PHYSFS_ARCHIVE_VDF)
+    add_definitions(-DPHYSFS_SUPPORTS_VDF=0)
+endif()
+
+
+option(PHYSFS_BUILD_STATIC "Build static library" TRUE)
+if(PHYSFS_BUILD_STATIC)
+    add_library(physfs-static STATIC ${PHYSFS_SRCS})
+    # Don't rename this on Windows, since DLLs will also produce an import
+    #  library named "physfs.lib" which would conflict; Unix tend to like the
+    #  same library name with a different extension for static libs, but
+    #  Windows can just have a separate name.
+    if(NOT MSVC)
+        set_target_properties(physfs-static PROPERTIES OUTPUT_NAME "physfs")
+	target_compile_options(physfs-static PRIVATE -fno-stack-protector)
+    endif()
+    if(WINRT)
+        # Ignore LNK4264 warnings; we don't author any WinRT components, just consume them, so we're okay in a static library.
+		set_target_properties(physfs-static PROPERTIES VS_WINRT_COMPONENT True)
+        set_target_properties(physfs-static PROPERTIES STATIC_LIBRARY_FLAGS "/ignore:4264")
+    endif()
+
+    set(PHYSFS_LIB_TARGET physfs-static)
+    set(PHYSFS_INSTALL_TARGETS ${PHYSFS_INSTALL_TARGETS} ";physfs-static")
+endif()
+
+option(PHYSFS_BUILD_SHARED "Build shared library" TRUE)
+if(PHYSFS_BUILD_SHARED)
+    add_library(physfs SHARED ${PHYSFS_SRCS})
+    set_target_properties(physfs PROPERTIES MACOSX_RPATH 1)
+    set_target_properties(physfs PROPERTIES VERSION ${PHYSFS_VERSION})
+    set_target_properties(physfs PROPERTIES SOVERSION ${PHYSFS_SOVERSION})
+    if(WINRT)
+		set_target_properties(physfs PROPERTIES VS_WINRT_COMPONENT True)
+    endif()
+    target_link_libraries(physfs ${OPTIONAL_LIBRARY_LIBS} ${OTHER_LDFLAGS})
+    set(PHYSFS_LIB_TARGET physfs)
+    set(PHYSFS_INSTALL_TARGETS ${PHYSFS_INSTALL_TARGETS} ";physfs")
+endif()
+
+if(NOT PHYSFS_BUILD_SHARED AND NOT PHYSFS_BUILD_STATIC)
+    message(FATAL "Both shared and static libraries are disabled!")
+endif()
+
+# CMake FAQ says I need this...
+if(PHYSFS_BUILD_SHARED AND PHYSFS_BUILD_STATIC AND NOT WINDOWS)
+    set_target_properties(physfs PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+    set_target_properties(physfs-static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+endif()
+
+option(PHYSFS_BUILD_TEST "Build stdio test program." TRUE)
+mark_as_advanced(PHYSFS_BUILD_TEST)
+if(PHYSFS_BUILD_TEST)
+    find_path(READLINE_H readline/readline.h)
+    find_path(HISTORY_H readline/history.h)
+    if(READLINE_H AND HISTORY_H)
+        find_library(CURSES_LIBRARY NAMES curses ncurses)
+        set(CMAKE_REQUIRED_LIBRARIES ${CURSES_LIBRARY})
+        find_library(READLINE_LIBRARY readline)
+        if(READLINE_LIBRARY)
+            set(HAVE_SYSTEM_READLINE TRUE)
+            set(TEST_PHYSFS_LIBS ${TEST_PHYSFS_LIBS} ${READLINE_LIBRARY} ${CURSES_LIBRARY})
+            include_directories(SYSTEM ${READLINE_H} ${HISTORY_H})
+            add_definitions(-DPHYSFS_HAVE_READLINE=1)
+        endif()
+    endif()
+    add_executable(test_physfs test/test_physfs.c)
+    target_link_libraries(test_physfs ${PHYSFS_LIB_TARGET} ${TEST_PHYSFS_LIBS} ${OTHER_LDFLAGS})
+    set(PHYSFS_INSTALL_TARGETS ${PHYSFS_INSTALL_TARGETS} ";test_physfs")
+endif()
+
+install(TARGETS ${PHYSFS_INSTALL_TARGETS}
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib${LIB_SUFFIX}
+        ARCHIVE DESTINATION lib${LIB_SUFFIX})
+install(FILES src/physfs.h DESTINATION include)
+
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+    set(PHYSFS_OUTPUT_DOXYFILE "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile"
+        "${PHYSFS_OUTPUT_DOXYFILE}"
+        COPYONLY
+    )
+    file(APPEND "${PHYSFS_OUTPUT_DOXYFILE}" "\n\n# Below auto-generated by cmake...\n\n")
+    file(APPEND "${PHYSFS_OUTPUT_DOXYFILE}" "PROJECT_NUMBER = \"${PHYSFS_VERSION}\"\n")
+    file(APPEND "${PHYSFS_OUTPUT_DOXYFILE}" "OUTPUT_DIRECTORY = \"${CMAKE_CURRENT_BINARY_DIR}/docs\"\n")
+    file(APPEND "${PHYSFS_OUTPUT_DOXYFILE}" "\n# End auto-generated section.\n\n")
+
+    set(PHYSFS_TARGETNAME_DOCS "docs" CACHE STRING "Name of 'docs' build target")
+    add_custom_target(
+        ${PHYSFS_TARGETNAME_DOCS}
+        ${DOXYGEN_EXECUTABLE} "${PHYSFS_OUTPUT_DOXYFILE}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        COMMENT "Building documentation in 'docs' directory..."
+    )
+else()
+    message(STATUS "Doxygen not found. You won't be able to build documentation.")
+endif()
+
+if(UNIX)
+    set(PHYSFS_TARBALL "${CMAKE_CURRENT_SOURCE_DIR}/../physfs-${PHYSFS_VERSION}.tar.bz2")
+
+    set(PHYSFS_TARGETNAME_DIST "dist" CACHE STRING "Name of 'dist' build target")
+    add_custom_target(
+        ${PHYSFS_TARGETNAME_DIST}
+        hg archive -t tbz2 "${PHYSFS_TARBALL}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        COMMENT "Building source tarball '${PHYSFS_TARBALL}'..."
+    )
+
+    set(PHYSFS_TARGETNAME_UNINSTALL "uninstall" CACHE STRING "Name of 'uninstall' build target")
+    add_custom_target(
+        ${PHYSFS_TARGETNAME_UNINSTALL}
+        "${CMAKE_CURRENT_SOURCE_DIR}/extras/uninstall.sh"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        COMMENT "Uninstall the project..."
+    )
+endif()
+
+if(NOT MSVC)
+    configure_file(
+        "extras/physfs.pc.in"
+        "extras/physfs.pc"
+        @ONLY
+    )
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/extras/physfs.pc"
+        DESTINATION "lib${LIB_SUFFIX}/pkgconfig"
+    )
+endif()
+
+macro(message_bool_option _NAME _VALUE)
+    if(${_VALUE})
+        message(STATUS "  ${_NAME}: enabled")
+    else()
+        message(STATUS "  ${_NAME}: disabled")
+    endif()
+endmacro()
+
+message(STATUS "PhysicsFS will build with the following options:")
+message_bool_option("ZIP support" PHYSFS_ARCHIVE_ZIP)
+message_bool_option("7zip support" PHYSFS_ARCHIVE_7Z)
+message_bool_option("GRP support" PHYSFS_ARCHIVE_GRP)
+message_bool_option("WAD support" PHYSFS_ARCHIVE_WAD)
+message_bool_option("HOG support" PHYSFS_ARCHIVE_HOG)
+message_bool_option("MVL support" PHYSFS_ARCHIVE_MVL)
+message_bool_option("QPAK support" PHYSFS_ARCHIVE_QPAK)
+message_bool_option("SLB support" PHYSFS_ARCHIVE_SLB)
+message_bool_option("VDF support" PHYSFS_ARCHIVE_VDF)
+message_bool_option("ISO9660 support" PHYSFS_ARCHIVE_ISO9660)
+message_bool_option("Build static library" PHYSFS_BUILD_STATIC)
+message_bool_option("Build shared library" PHYSFS_BUILD_SHARED)
+message_bool_option("Build stdio test program" PHYSFS_BUILD_TEST)
+if(PHYSFS_BUILD_TEST)
+    message_bool_option("  Use readline in test program" HAVE_SYSTEM_READLINE)
+endif()
+
+# end of CMakeLists.txt ...
+

--- a/patched_make_files/templeos-loader/CMakeLists.txt
+++ b/patched_make_files/templeos-loader/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1)
+project("templeos-loader")
+
+find_package(PhysFS REQUIRED)
+
+add_executable("templeos-loader"
+        loader.c
+        load_kernel.c
+        load_kernel.h
+        memory_map.c
+        memory_map.h
+        symtable.c
+        symtable.h
+        templeos.h
+        vsyscall.h
+        vsyscall.c
+        vfs.h vfs.c)
+
+target_include_directories("templeos-loader" PRIVATE ${PHYSFS_INCLUDE_DIR})
+target_link_libraries("templeos-loader" PRIVATE ${PHYSFS_LIBRARY} -static)
+target_compile_options("templeos-loader" PRIVATE -fno-stack-protector)


### PR DESCRIPTION
These make file changes allow it to work on Ubuntu 18.04 64-bit.  They shouldn't cause a problem on any modern Linux distribution.  It might be good just to always use these patches?