### PR TITLE
Add support for multiple VFS drives

### DIFF
--- a/loader.c
+++ b/loader.c
@@ -101,8 +101,8 @@ int main(int argc, char** argv) {
 	//printf("pid: %d\n", getpid());
     //printf("pc: %p\n", get_pc());
 
-    if (argc != 4) {
-        fprintf(stderr, "usage: templeos-loader <kernel> <rootfs> <writable>\n");
+    if (argc != 6) {
+        fprintf(stderr, "usage: templeos-loader <kernel> <rootfs> <rootfs writable> <vfs> <vfs writable>\n");
         exit(-1);
     }
 
@@ -111,8 +111,10 @@ int main(int argc, char** argv) {
         exit(-1);
 
 	/* load kernel image */
-    if (load_kernel(argv[1], (void*) KERNEL_START, KERNEL_END - KERNEL_START) < 0)
+    if (load_kernel(argv[1], (void*) KERNEL_START, KERNEL_END - KERNEL_START) < 0) {
+        fprintf(stderr, "failed to load kernel %s\n", argv[1]);
         exit(-1);
+    }
 
 	/* locate entry point */
     struct sym* KMain_sym = findsym("VKMain");
@@ -127,8 +129,11 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
-    /* VFS init */
-    vfs_init(argv[0], argv[2], argv[3]);
+    /* ROOTFS init (Temple OS drive C) */
+    vfs_init(argv[0], argv[2], argv[3], 0);
+
+    /* VFS init (Temple OS drive D) */
+    vfs_init(argv[0], argv[4], argv[5], 1);
 
     /* install trap handler */
     struct sigaction sa = { };

--- a/templeos.h
+++ b/templeos.h
@@ -1,3 +1,5 @@
+#ifndef TEMPLEOS_H
+#define TEMPLEOS_H
 
 #include <stdint.h>
 
@@ -77,3 +79,5 @@ struct CHashTable10 {
 #define RS_ATTR_COMPRESSED      0x400 //Z
 #define RS_ATTR_CONTIGUOUS      0x800 //C
 #define RS_ATTR_FIXED           0x1000 //F
+
+#endif

--- a/vfs.c
+++ b/vfs.c
@@ -27,54 +27,55 @@ struct vfs_dir_t {
 };
 
 enum { MAX_ASSIGNMENTS = 10000 };       // FIXME: handle dynamically
-struct clus_assignment assignments[MAX_ASSIGNMENTS];
+struct clus_assignment assignments[NUM_DRIVES][MAX_ASSIGNMENTS];
 
-static struct clus_assignment* get_node_by_clus(clus_t clus) {
+static struct clus_assignment* get_node_by_clus(clus_t clus, const unsigned char dv) {
     intptr_t index = clus - CLUS_MIN;
 
-    if (index >= 0 && index < MAX_ASSIGNMENTS && assignments[index].path != NULL) {
-        return &assignments[index];
+    if (index >= 0 && index < MAX_ASSIGNMENTS && assignments[dv][index].path != NULL) {
+        return &assignments[dv][index];
     }
 
     return NULL;
 }
 
-static struct clus_assignment* get_node_by_path(char const* path) {
+static struct clus_assignment* get_node_by_path(char const* path, const unsigned char dv) {
     size_t i;
 
-    for (i = 0; i < MAX_ASSIGNMENTS && assignments[i].path != NULL; i++) {
-        if (strcmp(assignments[i].path, path) == 0) {
-            return &assignments[i];
+    for (i = 0; i < MAX_ASSIGNMENTS && assignments[dv][i].path != NULL; i++) {
+        if (strcmp(assignments[dv][i].path, path) == 0) {
+            return &assignments[dv][i];
         }
     }
 
-    assignments[i].path = strdup(path);
-    assignments[i].clus = CLUS_MIN + i;
-    return &assignments[i];
+    assignments[dv][i].path = strdup(path);
+    assignments[dv][i].clus = CLUS_MIN + i;
+    return &assignments[dv][i];
 }
 
-void vfs_init(const char* argv0, const char* vfspath, const char* writepath) {
+void vfs_init(const char* argv0, const char* vfspath, const char* writepath, const unsigned char dv) {
     // TODO: handle errors
-    PHYSFS_init(argv0);
-    PHYSFS_setWriteDir(writepath);
+    printf("Init dv = %d\n",dv);
+    PHYSFS_init(argv0, dv);
+    PHYSFS_setWriteDir(writepath, dv);
 
     // "The write dir is not included in the search path unless you specifically add it."
-    PHYSFS_mount(writepath, "/", 1);
-    PHYSFS_mount(vfspath, "/", 1);
+    PHYSFS_mount(writepath, "/", 1, dv);
+    PHYSFS_mount(vfspath, "/", 1, dv);
 }
 
-int vfs_closedir(struct vfs_dir_t* dirp) {
+int vfs_closedir(struct vfs_dir_t* dirp, const unsigned char dv) {
     free(dirp->path);
-    PHYSFS_freeList(dirp->list);
+    PHYSFS_freeList(dirp->list, dv);
     free(dirp);
 }
 
-size_t vfs_fget(const char* path, uint8_t* buf, size_t bufsiz) {
-    PHYSFS_File* f = PHYSFS_openRead(path);
+size_t vfs_fget(const char* path, uint8_t* buf, size_t bufsiz, const unsigned char dv) {
+    PHYSFS_File* f = PHYSFS_openRead(path, dv);
 
     if (f) {
-        int64_t read = PHYSFS_readBytes(f, buf, bufsiz);
-        PHYSFS_close(f);
+        int64_t read = PHYSFS_readBytes(f, buf, bufsiz, dv);
+        PHYSFS_close(f, dv);
         return (read >= 0) ? read : 0;
     }
     else {
@@ -82,12 +83,12 @@ size_t vfs_fget(const char* path, uint8_t* buf, size_t bufsiz) {
     }
 }
 
-size_t vfs_fput(const char* path, const uint8_t* buf, size_t bufsiz) {
-    PHYSFS_File* f = PHYSFS_openWrite(path);
+size_t vfs_fput(const char* path, const uint8_t* buf, size_t bufsiz, const unsigned char dv) {
+    PHYSFS_File* f = PHYSFS_openWrite(path, dv);
 
     if (f) {
-        int64_t written = PHYSFS_writeBytes(f, buf, bufsiz);
-        PHYSFS_close(f);
+        int64_t written = PHYSFS_writeBytes(f, buf, bufsiz, dv);
+        PHYSFS_close(f, dv);
         return (written >= 0) ? written : 0;
     }
     else {
@@ -95,8 +96,8 @@ size_t vfs_fput(const char* path, const uint8_t* buf, size_t bufsiz) {
     }
 }
 
-int vfs_mkdir(const char* path) {
-    if (PHYSFS_mkdir(path) ) {
+int vfs_mkdir(const char* path, const unsigned char dv) {
+    if (PHYSFS_mkdir(path, dv) ) {
         return 0;
     }
     else {
@@ -104,8 +105,8 @@ int vfs_mkdir(const char* path) {
     }
 }
 
-struct vfs_dir_t* vfs_opendir(const char* path) {
-    char** list = PHYSFS_enumerateFiles(path);
+struct vfs_dir_t* vfs_opendir(const char* path, const unsigned char dv) {
+    char** list = PHYSFS_enumerateFiles(path, dv);
 
     if (!list) {
         return NULL;
@@ -118,7 +119,7 @@ struct vfs_dir_t* vfs_opendir(const char* path) {
     return d;
 }
 
-int vfs_readdir(struct vfs_dir_t* dirp, struct CHostFsStat* st_out) {
+int vfs_readdir(struct vfs_dir_t* dirp, struct CHostFsStat* st_out, const unsigned char dv) {
     if (!dirp->list[dirp->pos]) {
         return -1;
     }
@@ -126,23 +127,23 @@ int vfs_readdir(struct vfs_dir_t* dirp, struct CHostFsStat* st_out) {
     char buf[4096];
     snprintf(buf, sizeof(buf), "%s/%s", dirp->path, dirp->list[dirp->pos++]);
 
-    if (vfs_stat(buf, st_out) != 0) {
+    if (vfs_stat(buf, st_out, dv) != 0) {
         // maybe file disappeared in the mean-time?
         // re-try in a recursive way. not the cleanest design.
-        return vfs_readdir(dirp, st_out);
+        return vfs_readdir(dirp, st_out, dv);
     }
 
     return 0;
 }
 
-int vfs_stat(const char* path, struct CHostFsStat* st_out) {
+int vfs_stat(const char* path, struct CHostFsStat* st_out, const unsigned char dv) {
     PHYSFS_Stat st;
 
-    if (!PHYSFS_stat(path, &st)) {
+    if (!PHYSFS_stat(path, &st, dv)) {
         return -1;
     }
 
-    struct clus_assignment* assignment = get_node_by_path(path);
+    struct clus_assignment* assignment = get_node_by_path(path, dv);
 
     if (!assignment) {
         return -1;
@@ -160,8 +161,8 @@ int vfs_stat(const char* path, struct CHostFsStat* st_out) {
     return 0;
 }
 
-int vfs_statclus(clus_t clus, struct CHostFsStat* st_out) {
-    struct clus_assignment* assignment = get_node_by_clus(clus);
+int vfs_statclus(clus_t clus, struct CHostFsStat* st_out, const unsigned char dv) {
+    struct clus_assignment* assignment = get_node_by_clus(clus, dv);
 
     if (!assignment) {
         return -1;
@@ -169,7 +170,7 @@ int vfs_statclus(clus_t clus, struct CHostFsStat* st_out) {
 
     PHYSFS_Stat st;
 
-    if (!PHYSFS_stat(assignment->path, &st)) {
+    if (!PHYSFS_stat(assignment->path, &st, dv)) {
         return -1;
     }
 
@@ -184,8 +185,8 @@ int vfs_statclus(clus_t clus, struct CHostFsStat* st_out) {
     return 0;
 }
 
-int vfs_unlink(const char* path) {
-    if (PHYSFS_delete(path) ) {
+int vfs_unlink(const char* path, const unsigned char dv) {
+    if (PHYSFS_delete(path, dv) ) {
         return 0;
     }
     else {

--- a/vfs.h
+++ b/vfs.h
@@ -5,20 +5,22 @@
 
 #include <stdio.h>
 
+#define NUM_DRIVES 5
+
 typedef int64_t clus_t;
 
-void vfs_init(const char* argv0, const char* vfspath, const char* writepath);
+void vfs_init(const char* argv0, const char* vfspath, const char* writepath, unsigned char dv);
 
-size_t vfs_fget(const char* path, uint8_t* buf, size_t bufsiz);
-size_t vfs_fput(const char* path, const uint8_t* buf, size_t bufsiz);
-int vfs_stat(const char* path, struct CHostFsStat* st_out);
-int vfs_statclus(clus_t clus, struct CHostFsStat* st_out);
-int vfs_unlink(const char* path);
+size_t vfs_fget(const char* path, uint8_t* buf, size_t bufsiz, const unsigned char dv);
+size_t vfs_fput(const char* path, const uint8_t* buf, size_t bufsiz, const unsigned char dv);
+int vfs_stat(const char* path, struct CHostFsStat* st_out, const unsigned char dv);
+int vfs_statclus(clus_t clus, struct CHostFsStat* st_out, const unsigned char dv);
+int vfs_unlink(const char* path, const unsigned char dv);
 
-int vfs_mkdir(const char* path);
+int vfs_mkdir(const char* path, const unsigned char dv);
 
-struct vfs_dir_t* vfs_opendir(const char* path);
-int vfs_readdir(struct vfs_dir_t* dirp, struct CHostFsStat* st_out);
-int vfs_closedir(struct vfs_dir_t* dirp);
+struct vfs_dir_t* vfs_opendir(const char* path, const unsigned char dv);
+int vfs_readdir(struct vfs_dir_t* dirp, struct CHostFsStat* st_out, const unsigned char dv);
+int vfs_closedir(struct vfs_dir_t* dirp, const unsigned char dv);
 
 #endif

--- a/vsyscall.h
+++ b/vsyscall.h
@@ -32,6 +32,6 @@ struct CHostFsStat {
     char*       name;
 };
 
-int64_t vsyscall_dispatcher(int64_t num, int64_t arg1, int64_t arg2, int64_t arg3);
+int64_t vsyscall_dispatcher(int64_t num, int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4);
 
 #endif


### PR DESCRIPTION
Expand Syscalls to 4 args
Add second virtual drive D mounted to path provided on command line
Output error message if kernel fails to load

For use with corresponding change in Shrine-v6 and requires PhysFS from:
https://github.com/ljward10/physfslt-3.0.2/tree/feature/MultiLite

