### PR TITLE
Update README and remake-holycrt.sh for static build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ However, the primary goal is not "to bring HolyC to Linux". The TempleOS program
 ## Building prerequisites
 
 glibc definitely does not appreciate the way we handle memory.
-For this reason, to avoid crashing, you must use a libc that is more "accomodating", such as musl
+For this reason, to avoid crashing, you must use a libc that is more "accomodating", such as musl.
+CMake 3.13 and the Python3 dataclasses module are also required.
 
 ### Build musl libc
 
@@ -44,7 +45,7 @@ For this reason, to avoid crashing, you must use a libc that is more "accomodati
     mkdir -p CmpOutput
 
     env STARTOS=D:/HolyCRT/CmpHolyCRT.HC \
-        ./cmake-build-debug/templeos \
+        ./cmake-build-debug/templeoskernel \
         --drive=C,MiniSystem \
         --drive=D,.,CmpOutput
 

--- a/remake-holycrt.sh
+++ b/remake-holycrt.sh
@@ -3,6 +3,6 @@
 mkdir -p CmpOutput
 
 env STARTOS=D:/HolyCRT/CmpHolyCRT.HC \
-    ./cmake-build-debug/templeos-loader CmpOutput/HolyCRT.BIN \
+    ./cmake-build-debug/templeoskernel \
     --drive=C,MiniSystem \
     --drive=D,.,CmpOutput


### PR DESCRIPTION
I was able to build this on Ubuntu, but because the version of CMake on Ubuntu is less than 3.13, I had to modify my CMakeLists.txt to use set_target_properties instead of target_link_options.  If you want me to add a pull request for that change so people can use older versions of CMake let me know.